### PR TITLE
Enable caching of NTP packages on Ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 ntp_pkg_state: installed
+ntp_pkg_auto_update: yes
+ntp_pkg_cache_valid_time: 3600
 ntp_service_state: started
 ntp_service_enabled: yes
 
@@ -26,6 +28,6 @@ ntp_config_keys: no
 ntp_config_trustedkey: no
 ntp_config_requestkey: no
 ntp_config_controlkey: no
-ntp_config_broadcast: no 
+ntp_config_broadcast: no
 ntp_config_broadcastclient: no
 ntp_config_multicastclient: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   tags: ["packages","ntp"]
 
 - name: Install the required packages in Debian derivatives
-  apt: name={{ item }} state={{ ntp_pkg_state }} update_cache=yes
+  apt: name={{ item }} state={{ ntp_pkg_state }} update_cache={{ ntp_pkg_auto_update }} cache_valid_time={{ ntp_pkg_cache_valid_time }}
   with_items: ntp_pkgs
   when: ansible_os_family == 'Debian'
   tags: ["packages","ntp"]


### PR DESCRIPTION
Hi

Currently the role updates the ntp package cache every time it's run. I prefer to centrally manage apt-cache updates, so I've made this an optional parameter (defaulting to true, with a cache time of an hour).

Feedback welcome. Thanks!

Oskar
