### PR TITLE
listen on external interfaces by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,7 @@ ntp_config_restrict:
 - '127.0.0.1'
 - '::1'
 
-ntp_config_listen:
-- '127.0.0.1'
+ntp_config_listen: []
 
 ntp_config_filegen:
 - 'loopstats file loopstats type day enable'


### PR DESCRIPTION
Commit 371b18c restricted listening to 127.0.0.1 (i.e., adding
`interface listen 127.0.0.1` to the generated `/etc/ntp.conf`), but
this prevents `ntpd` from syncing with external servers (e.g., the
ubuntu pool).

This commit removes that default, so that the role works as intended
without any additional configuration. Users that want to restrict all
communication to localhost can override the default
`ntp_config_listen` variable.