### PR TITLE
Add support for Solaris

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 ntp_pkg_state: 'installed'
 ntp_service_state: 'started'
 ntp_service_enabled: 'yes'
+ntp_config_dest: '/etc/ntp.conf'
 
 ntp_config_server: [ '0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org' ]
 ntp_config_restrict:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,7 @@ galaxy_info:
    - name: Debian
      versions:
       - wheezy
+   - name: Solaris
   categories:
    - system
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,8 +13,12 @@
   when: ansible_os_family == 'Debian'
   tags: [ 'package', 'ntp' ]
 
+- name: Install the required packages in Solaris
+  pkg5: name=service/network/ntp state={{ ntp_pkg_state }}
+  when: ansible_os_family == 'Solaris'
+
 - name: Copy the ntp.conf template file
-  template: src=ntp.conf.j2 dest=/etc/ntp.conf
+  template: src=ntp.conf.j2 dest={{ ntp_config_dest }}
   notify:
   - restart ntp
   tags: [ 'configuration', 'package', 'ntp' ]

--- a/vars/Solaris.yml
+++ b/vars/Solaris.yml
@@ -1,0 +1,4 @@
+---
+ntp_service_name: ntp
+ntp_config_driftfile: /var/lib/ntp/ntp.drift
+ntp_config_dest: /etc/inet/ntp.conf


### PR DESCRIPTION
Add support for Solaris. I've tested on OmniOS r151014. This at the moment only supports Solaris variants using IPS packaging. 
