### PR TITLE
Step to new package module to support also dnf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,8 @@
   include_vars: '{{ ansible_os_family }}.yml'
   tags: [ 'configuration', 'package', 'service', 'ntp' ]
 
-- name: Install the required packages in Redhat derivatives
-  yum: name=ntp state={{ ntp_pkg_state }}
-  when: ansible_os_family == 'RedHat'
-  tags: [ 'package', 'ntp' ]
-
-- name: Install the required packages in Debian derivatives
-  apt: name=ntp state={{ ntp_pkg_state }}
-  when: ansible_os_family == 'Debian'
-  tags: [ 'package', 'ntp' ]
+- name: Install the required packages
+  package: name=ntp state=latest
 
 - name: Copy the ntp.conf template file
   template: src=ntp.conf.j2 dest=/etc/ntp.conf


### PR DESCRIPTION
You role fails on modern Fedora version because `yum` replaced by `dnf`.

Hopefully in ansible 2.0 new `package` module appeared to drop all such conditional burden (http://serverfault.com/questions/695490/parametric-ansible-command-based-on-facts-how-to-do-it).