### PR TITLE
Disable monitor if needed

### DIFF
--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -26,6 +26,13 @@ interface listen {{ listen }}
 restrict {{ restrict }}
 {% endfor %}
 
+{% for restrict in ntp_config_restrict %}
+restrict {{ restrict }}
+{% endfor %}
+
+
+
+
 {% if ntp_config_crypto %}
 crypto
 {% endif %}
@@ -58,6 +65,6 @@ broadcast {{ ntp_config_broadcast }}
 broadcastclient
 {% endif %}
 
-{% if ntp_config_multicastclient %}
-multicastclient {{ ntp_config_multicastclient }}
+{% if ntp_disable_monitor %}
+disable monitor
 {% endif %}


### PR DESCRIPTION
Disable the monitoring facility to prevent amplification attacks using ntpdc monlist command when default restrict does not include the noquery flag.