### PR TITLE
update apt cache to avoid installation issues

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   tags: [ 'package', 'ntp' ]
 
 - name: Install the required packages in Debian derivatives
-  apt: name=ntp state={{ ntp_pkg_state }}
+  apt: name=ntp state={{ ntp_pkg_state }} update_cache=yes cache_valid_time=86400
   when: ansible_os_family == 'Debian'
   tags: [ 'package', 'ntp' ]
 


### PR DESCRIPTION
I noticed this was previously removed. However, I have issues with the EC2 Ubuntu sources when this package is the first to be installed.