### PR TITLE
Fix Ansible warning about state

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ntp_pkg_state: 'installed'
+ntp_pkg_state: 'present'
 ntp_service_state: 'started'
 ntp_service_enabled: 'yes'
 


### PR DESCRIPTION
Installed is deprecated in favor of present and will be removed in Ansible
2.9.